### PR TITLE
add configuration hooks to apis

### DIFF
--- a/src/main/java/com/liveperson/api/MessagingConsumer.java
+++ b/src/main/java/com/liveperson/api/MessagingConsumer.java
@@ -27,10 +27,11 @@ import com.liveperson.api.infra.ServiceName;
 import com.liveperson.api.infra.ws.annotations.WebsocketNotification;
 import com.liveperson.api.infra.ws.annotations.WebsocketPath;
 import com.liveperson.api.infra.ws.annotations.WebsocketReq;
+import retrofit2.http.Header;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
-import retrofit2.http.Header;
 
 @ServiceName("asyncMessagingEnt")
 @WebsocketPath("{protocol}://{domain}/ws_api/account/{account}/messaging/consumer?v=3")
@@ -54,6 +55,12 @@ public interface MessagingConsumer {
 
     @WebsocketReq("ms.SubscribeMessagingEvents")
     CompletableFuture<JsonNode> subscribeMessagingEvents(JsonNode body);
+
+    @WebsocketReq("cqm.SubscribeExConversations")
+    CompletableFuture<JsonNode> subscribeExConversationEvents(JsonNode body);
+
+    @WebsocketReq("cqm.UnsubscribeExConversations")
+    CompletableFuture<JsonNode> unsubscribeExConversationEvents(JsonNode body);
 
     @WebsocketNotification("ms.MessagingEventNotification")
     Predicate<JsonNode> onMessagingEventNotification(Consumer<JsonNode> cb);

--- a/src/main/java/com/liveperson/api/infra/GeneralAPI.java
+++ b/src/main/java/com/liveperson/api/infra/GeneralAPI.java
@@ -24,18 +24,19 @@ package com.liveperson.api.infra;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.liveperson.api.infra.ws.annotations.WebsocketPath;
+import okhttp3.OkHttpClient;
+import retrofit2.Call;
+import retrofit2.Retrofit;
+import retrofit2.converter.jackson.JacksonConverterFactory;
+import retrofit2.http.GET;
+import retrofit2.http.Path;
+
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import retrofit2.Call;
-import retrofit2.Retrofit;
-import retrofit2.converter.jackson.JacksonConverterFactory;
-import retrofit2.http.GET;
-import retrofit2.http.Path;
 
 public class GeneralAPI {
     public interface CSDS {
@@ -59,11 +60,16 @@ public class GeneralAPI {
             throw new RuntimeException(ex);
         }
     }
-    public static <T> T apiEndPoint(final String baseUrl, final Class<T> clz) {
+    public  static <T> T apiEndPoint(final String baseUrl, final Class<T> clz,OkHttpClient client) {
         return new Retrofit.Builder()
                 .baseUrl(baseUrl)
+                .client(client)
                 .addConverterFactory(JacksonConverterFactory.create())
                 .build().create(clz);
+    }
+    public static <T> T apiEndPoint(final String baseUrl, final Class<T> clz) {
+        return apiEndPoint(baseUrl,clz, new OkHttpClient());
+
     }
 
     public static <T> T apiEndpoint(final Map<String, String> domains, final Class<T> clz) {

--- a/src/main/java/com/liveperson/api/infra/ws/HandlerManagerImpl.java
+++ b/src/main/java/com/liveperson/api/infra/ws/HandlerManagerImpl.java
@@ -44,7 +44,6 @@ public class HandlerManagerImpl<T> implements HandlerManager<T> {
         final Predicate<T> registeredFilter = p -> {
             if (matcher.test(p)) {
                 filter.accept(p);
-                return false; // do not continue processing
             }
             return true; // continue processing
         };

--- a/src/test/java/com/liveperson/api/MessagingTest.java
+++ b/src/test/java/com/liveperson/api/MessagingTest.java
@@ -23,28 +23,31 @@ package com.liveperson.api;
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
+
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import static com.google.common.collect.ImmutableMap.of;
-import java.util.Map;
-import java.util.Optional;
 import com.liveperson.api.infra.GeneralAPI;
 import com.liveperson.api.infra.ws.WebsocketService;
-import java.io.IOException;
 import org.junit.Before;
 import org.junit.Test;
-import static org.hamcrest.CoreMatchers.*;
-import static org.hamcrest.text.IsEmptyString.*;
-import static org.hamcrest.collection.IsCollectionWithSize.*;
-import static org.hamcrest.number.OrderingComparison.greaterThan;
+import org.slf4j.LoggerFactory;
 
-import static org.junit.Assert.*;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.LoggerFactory;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.number.OrderingComparison.greaterThan;
+import static org.hamcrest.text.IsEmptyString.isEmptyString;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 public class MessagingTest {
     public static final String LP_ACCOUNT = System.getenv("LP_ACCOUNT");
@@ -71,7 +74,7 @@ public class MessagingTest {
     public void testUMS() throws Exception {
         CountDownLatch cdl = new CountDownLatch(1);
         WebsocketService<MessagingConsumer> consumer = WebsocketService.create(MessagingConsumer.class,
-                of("protocol", "wss", "account", LP_ACCOUNT), domains);
+                of("protocol", "wss", "account", LP_ACCOUNT), domains,10);
 
         consumer.methods().initConnection(OM.createObjectNode().put("jwt", jwt)).get();
         String convId = consumer.methods().consumerRequestConversation().get().path("body").path("conversationId").asText();

--- a/src/test/java/com/liveperson/api/infra/ws/WsTest.java
+++ b/src/test/java/com/liveperson/api/infra/ws/WsTest.java
@@ -22,34 +22,30 @@
  */
 package com.liveperson.api.infra.ws;
 
-import com.liveperson.api.infra.ws.annotations.WebsocketPath;
-import com.liveperson.api.infra.ws.annotations.WebsocketReq;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import com.codahale.metrics.MetricRegistry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import static com.google.common.collect.ImmutableMap.of;
 import com.google.common.util.concurrent.RateLimiter;
-import java.io.IOException;
-import org.junit.Test;
+import com.liveperson.api.infra.ws.annotations.WebsocketPath;
+import com.liveperson.api.infra.ws.annotations.WebsocketReq;
 import com.liveperson.api.infra.ws.helper.MyApp;
-import static io.dropwizard.util.Duration.seconds;
-import static java.lang.System.nanoTime;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.Phaser;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import org.eclipse.jetty.server.Server;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.concurrent.*;
+
+import static com.google.common.collect.ImmutableMap.of;
+import static io.dropwizard.util.Duration.seconds;
+import static java.lang.System.nanoTime;
+import static java.util.concurrent.TimeUnit.SECONDS;
 
 @Category(SlowTests.class)
 public class WsTest {
@@ -69,7 +65,7 @@ public class WsTest {
     @Test
     public void testFastRequests() throws Exception {
         WebsocketService<TestMethods> connection = WebsocketService.create(TestMethods.class,
-                of("domain", "localhost:48080"));
+                of("domain", "localhost:48080"),10);
 
         Phaser phaser = new Phaser(1); //register also the managing thread.
         RateLimiter rl = RateLimiter.create(100);
@@ -108,7 +104,7 @@ public class WsTest {
             rlConnect.acquire();
             es.execute(() -> {
                 q.add(WebsocketService.create(TestMethods.class,
-                        of("domain", "localhost:48080")));
+                        of("domain", "localhost:48080"),10));
             });
         }
 


### PR DESCRIPTION
support timeout for WS service;
allow passing of clients to retrofit apis wrapper;
handler will not stop upon first match;
add consumer support for un/subscribe from/to extended conversations;